### PR TITLE
Fix restart fail on windows.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -98,6 +98,9 @@ export const run = async (file: string) => {
     ignorePermissionErrors: true,
     cwd: process.cwd(),
   }).on('all', async (event, filepath) => {
+    if(process.platform=='win32'){
+      filepath=filepath.replace(/\\/g,'/')
+    }
     if (watchFiles.has(filepath)) {
       await killProcess({ pid: cmd.pid })
       const result = await build(file, 'temp')


### PR DESCRIPTION
When on windows, the path separator is double backslash, so restart not work.
![image](https://user-images.githubusercontent.com/27798227/126928030-c87b86e8-936c-4421-ad57-16919452978a.png)
